### PR TITLE
APPCP-129 - Implement RFC5322-compliant* email validation

### DIFF
--- a/lib/utils/validation.ex
+++ b/lib/utils/validation.ex
@@ -25,12 +25,14 @@ defmodule Utils.Validation do
 
   def postal_code_regex, do: @postal_code_regex
 
-  @rfc_5322 ~r/^(?:[a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/
+  @rfc_5322 ~r/^(?:[a-zA-Z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-zA-Z0-9-]*[a-zA-Z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/
   @doc """
-  Validates whether a given string is an RFC5322-compliant email address.
+  Validates whether a given string is semantically valid, according to a modified version of the RFC5322 standard.
   For more information, see: https://emailregex.com/.
 
+  This modified version is case-insensitive, meaning uppercases will not break the validation.
   It does not validate whether the email address is used in the real world.
+  When handling email uniqueness in your app, it is your responsibility to do so case-insensitively. 
 
   Returns `true` or `false` depending on the validity of the email address.
   """

--- a/lib/utils/validation.ex
+++ b/lib/utils/validation.ex
@@ -3,6 +3,7 @@ defmodule Utils.Validation do
   This module contains functions related to validation
   """
 
+  @postal_code_regex ~r/^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ -]?\d[ABCEGHJ-NPRSTV-Z]\d$/i
   @doc """
   Validates whether a given string matches the Canada Post's addressing guidelines on postal codes.
   For more information, see: https://www.canadapost-postescanada.ca/cpc/en/support/articles/addressing-guidelines/postal-codes.page
@@ -22,6 +23,9 @@ defmodule Utils.Validation do
     )
   end
 
+  def postal_code_regex, do: @postal_code_regex
+
+  @rfc_5322 ~r/^(?:[a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/
   @doc """
   Validates whether a given string is an RFC5322-compliant email address.
   For more information, see: https://emailregex.com/.
@@ -30,8 +34,9 @@ defmodule Utils.Validation do
 
   Returns `true` or `false` depending on the validity of the email address.
   """
-  @rfc_5322 ~r/^(?:[a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/
   def email(email) do
     Regex.match?(@rfc_5322, email)
   end
+
+  def email_regex, do: @rfc_5322
 end

--- a/lib/utils/validation.ex
+++ b/lib/utils/validation.ex
@@ -4,21 +4,34 @@ defmodule Utils.Validation do
   """
 
   @doc """
-  Expects a string
+  Validates whether a given string matches the Canada Post's addressing guidelines on postal codes.
+  For more information, see: https://www.canadapost-postescanada.ca/cpc/en/support/articles/addressing-guidelines/postal-codes.page
 
-  Validate that the alphanumeric postal code is in the correct format and respects Canada Post rules.
-  It does not validate that the postal code is used in the real world. 
-  The validation is case insensitive.
+  It does not validate whether the postal code is used in the real world. 
+  The validation is case-insensitive.
   There can be spaces, dashes or nothing at all between the two groups of three characters.
 
-  It is up to the developper to format the postal code in the desired format once the result is deemed valid. 
+  It is up to the developer to format the postal code in the desired format once the result is deemed valid. 
 
-  Return `true` or `false` depending on the validity of the postal code.
+  Returns `true` or `false` depending on the validity of the postal code.
   """
   def postal_code(postal_code) do
     Regex.match?(
       ~r/^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ -]?\d[ABCEGHJ-NPRSTV-Z]\d$/i,
       postal_code
     )
+  end
+
+  @doc """
+  Validates whether a given string is an RFC5322-compliant email address.
+  For more information, see: https://emailregex.com/.
+
+  It does not validate whether the email address is used in the real world.
+
+  Returns `true` or `false` depending on the validity of the email address.
+  """
+  @rfc_5322 ~r/^(?:[a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/
+  def email(email) do
+    Regex.match?(@rfc_5322, email)
   end
 end

--- a/test/validation_test.exs
+++ b/test/validation_test.exs
@@ -1,7 +1,7 @@
 defmodule Utils.ValidationTest do
   use ExUnit.Case
 
-  describe("Validation.postal_code/2") do
+  describe("Validation.postal_code/1") do
     test("it starts with a letter") do
       refute Utils.Validation.postal_code("1A1 1A1")
       assert Utils.Validation.postal_code("A1B 2C3")
@@ -44,6 +44,71 @@ defmodule Utils.ValidationTest do
 
     test("the validation is case insensitive") do
       assert Utils.Validation.postal_code("a1b 2C3")
+    end
+  end
+
+  describe "Validation.email/1" do
+    test "it must be truthy for happiest path" do
+      assert Utils.Validation.email("foobar@rumandcode.io")
+    end
+
+    test "it must have exactly one '@' character" do
+      refute Utils.Validation.email("foobarrumandcode.io")
+      refute Utils.Validation.email("foobar@rumandcode@io")
+      assert Utils.Validation.email("foobar@rumandcode.io")
+    end
+
+    test "it must have a 'local part', AKA a string before the '@' symbol" do
+      refute Utils.Validation.email("@rumandcode.io")
+    end
+
+    test "it must have a 'domain part', AKA a string after the '@' symbol" do
+      refute Utils.Validation.email("foobar@")
+    end
+
+    test "its 'domain part' must have at least one '.'" do
+      refute Utils.Validation.email("foobar@rumandcodeio")
+      assert Utils.Validation.email("foobar@rumandcode.ca")
+      assert Utils.Validation.email("foobar@rumandcode.qc.ca")
+      assert Utils.Validation.email("foobar@rumandcode.gouv.qc.ca")
+      assert Utils.Validation.email("foobar@rumandcode.ti.gouv.qc.ca")
+      assert Utils.Validation.email("foobar@rumandcode.yes.this.is.still.a.valid.domain.io")
+    end
+
+    test "its 'local part' can support any alphanumeric characters" do
+      assert Utils.Validation.email("abcdefghijklmnopqrstuvwxyz0123456789@rumandcode.io")
+    end
+
+    test "its 'local part' can support any of a specific handful of special characters" do
+      assert Utils.Validation.email("!#$%&'*+./=?^_`{|}~-@rumandcode.io")
+    end
+
+    test "its 'domain part' can support any alphanumeric character" do
+      assert Utils.Validation.email("foobar@abcdefghijklmnopqrstuvwxyz0123456789.io")
+    end
+
+    test "its 'domain part' can only support the '-' as its special character, as long as it is in between alphanumeric characters" do
+      refute Utils.Validation.email("foobar@-.io")
+      refute Utils.Validation.email("foobar@-rum.io")
+      refute Utils.Validation.email("foobar@rum-.io")
+      refute Utils.Validation.email("foobar@rum-and-.io")
+      refute Utils.Validation.email("foobar@-rum-and.io")
+      assert Utils.Validation.email("foobar@rum-and.io")
+      assert Utils.Validation.email("foobar@rum-and-code.io")
+    end
+
+    test "the top level domain of its 'domain part' can only support the '-' character, as long as it is in between alphanumeric characters" do
+      refute Utils.Validation.email("foobar@rumandcode.-")
+      refute Utils.Validation.email("foobar@rumandcode.io-")
+      refute Utils.Validation.email("foobar@rumandcode.-io")
+      refute Utils.Validation.email("foobar@rumandcode.qc-ca-")
+      refute Utils.Validation.email("foobar@rumandcode.-qc-ca")
+      assert Utils.Validation.email("foobar@rumandcode.qc-ca")
+      assert Utils.Validation.email("foobar@rum-and-code.gouv-qc-ca")
+    end
+
+    test "its 'domain part' can be an IP Address" do
+      assert Utils.Validation.email("foobar@[127.0.0.1:587]")
     end
   end
 end

--- a/test/validation_test.exs
+++ b/test/validation_test.exs
@@ -79,12 +79,20 @@ defmodule Utils.ValidationTest do
       assert Utils.Validation.email("abcdefghijklmnopqrstuvwxyz0123456789@rumandcode.io")
     end
 
+    test "its 'local part' can support any upcased alpha characters" do
+      assert Utils.Validation.email("ABCDEFGHIJKLMNOPQRSTUVQXYZ@rumandcode.io")
+    end
+
     test "its 'local part' can support any of a specific handful of special characters" do
       assert Utils.Validation.email("!#$%&'*+./=?^_`{|}~-@rumandcode.io")
     end
 
     test "its 'domain part' can support any alphanumeric character" do
       assert Utils.Validation.email("foobar@abcdefghijklmnopqrstuvwxyz0123456789.io")
+    end
+
+    test "its 'domain part' can support any upcased alpha characters" do
+      assert Utils.Validation.email("foobar@ABCDEFGHIJKLMNOPQRSTUVQXYZ.IO")
     end
 
     test "its 'domain part' can only support the '-' as its special character, as long as it is in between alphanumeric characters" do


### PR DESCRIPTION
- Implements RF2322-compliant* email validation using the Regex provided at site: https://emailregex.com/
  - The regex used in this validation has been altered from the original RF2322 standard to accept upcased characters. This is because some Chantier apps, for performance purposes, will validate the uniqueness of the email only once the format of an email is valid. Entering a uppercase character in an email would normally be an invalid format, therefore bypassing the uniqueness validation.